### PR TITLE
Explicit injection annotations

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -30,7 +30,12 @@
     factory('$sessionStorage', _storageFactory('sessionStorage'));
 
     function _storageFactory(storageType) {
-        return function(
+        return [
+            '$rootScope',
+            '$browser',
+            '$window',
+
+        function(
             $rootScope,
             $browser,
             $window
@@ -95,7 +100,7 @@
             });
 
             return $storage;
-        };
+        }];
     }
 
 })();


### PR DESCRIPTION
Because the factory pattern used in the library isn't supported by ngmin,
minification (with enabled name mangling) breaks the dependency injection. This
adds explicit annotations with the array syntax.
