### PR TITLE
Ie fix

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -59,8 +59,7 @@
                 },
                 _last$storage;
 
-            for (var i = 0, k; i < webStorage.length; i++) {
-                k = webStorage.key(i);
+            for (var i = 0, k; i < webStorage.length && (k = webStorage.key(i)); i++) {
                 'ngStorage-' === k.slice(0, 10) && ($storage[k.slice(10)] = angular.fromJson(webStorage.getItem(k)));
             }
 


### PR DESCRIPTION
I'm developing a web site with angular and wanted to start using the local storage and came across ngStorage. It works like a charm on Chrome and Firefox but it came out with a strange error on Internet Explorer (Invalid Argument).

Turns out IE9 does not like the method key(0) when the local storage is empty and throws an exception instead of returning null as per the specification.

Changing the for loop to look at the localStorage.length instead fixes the problem.
