### PR TITLE
Degrade gracefully in IE on local files

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -59,6 +59,9 @@
                     },
                     _last$storage;
 
+                //degrade gracefully in Internet Explorer when loading page from filesystem
+                webStorage = webStorage || { setItem: function() {}, removeItem:function() {} };
+                
                 // (#8) `i < webStorage.length` is needed for IE9
                 for (var i = 0, k; i < webStorage.length && (k = webStorage.key(i)); i++) {
                     'ngStorage-' === k.slice(0, 10) && ($storage[k.slice(10)] = angular.fromJson(webStorage.getItem(k)));


### PR DESCRIPTION
localStorage is not available in Internet Explorer when loading files directly from the filesystem.
This "fix" prevents your whole app to crash. Everything works, but nothing gets saved.

I found a project, called jStorage (http://www.jstorage.info/) that tries to fix this issue.
