### PR TITLE
Use `$window.attachEvent` instead of `$window.addEventListener` on IE8

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -91,15 +91,19 @@
                 });
 
                 // (#6) Use `$window.addEventListener` instead of `angular.element` to avoid the jQuery-specific `event.originalEvent`
-                'localStorage' === storageType && $window.addEventListener('storage', function(event) {
-                    if ('ngStorage-' === event.key.slice(0, 10)) {
-                        event.newValue ? $storage[event.key.slice(10)] = angular.fromJson(event.newValue) : delete $storage[event.key.slice(10)];
+                if ('localStorage' === storageType) {
+                    var storageEventListener = function(event) {
+                        if ('ngStorage-' === event.key.slice(0, 10)) {
+                            event.newValue ? $storage[event.key.slice(10)] = angular.fromJson(event.newValue) : delete $storage[event.key.slice(10)];
 
-                        _last$storage = angular.copy($storage);
+                            _last$storage = angular.copy($storage);
 
-                        $rootScope.$apply();
-                    }
-                });
+                            $rootScope.$apply();
+                        }
+                    };
+
+                    $window.addEventListener ? $window.addEventListener('storage', storageEventListener) : $window.attachEvent('storage', storageEventListener);
+                }
 
                 return $storage;
             }


### PR DESCRIPTION
This is a fix to make localStorage work properly on IE8.

window.addEventListener doesn't exists in IE8, use window.attachEvent instead.

https://developer.mozilla.org/en-US/docs/Web/API/EventTarget.addEventListener
