### PR TITLE
Put ngStorage on NPM for those of us who use browserify for client-side package management

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,8 +34,8 @@ module.exports = function(grunt) {
             },
 
             build: {
-                src: '<%= pkg.name %>.js',
-                dest: '<%= pkg.name %>.min.js'
+                src: 'ngStorage.js',
+                dest: 'ngStorage.min.js'
             }
         }
     });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng-storage",
   "description": "localStorage and sessionStorage done right for AngularJS.",
   "homepage": "https://github.com/gsklee/ngStorage",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Gias Kay Lee",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng-storage",
   "description": "localStorage and sessionStorage done right for AngularJS.",
   "homepage": "https://github.com/gsklee/ngStorage",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Gias Kay Lee",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,12 @@
 {
   "name": "ng-storage",
+  "description": "localStorage and sessionStorage done right for AngularJS.",
+  "homepage": "https://github.com/gsklee/ngStorage",
   "version": "0.3.0",
   "author": "Gias Kay Lee",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/gsklee/ngStorage/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
-    "test": "./node_modules/.bin/grunt test"
+    "test": "grunt test"
   },
   "main": "ngStorage.js",
   "devDependencies": {
@@ -18,5 +15,37 @@
     "grunt-karma": "~0.7.1",
     "karma-mocha": "~0.1.0",
     "grunt-cli": "~0.1.11"
+  },
+  "directories": {
+    "test": "test"
+  },
+  "dependencies": {
+    "grunt": "^0.4.2",
+    "grunt-karma": "^0.7.2",
+    "grunt-cli": "^0.1.11",
+    "karma": "^0.10.9",
+    "karma-firefox-launcher": "^0.1.3",
+    "karma-html2js-preprocessor": "^0.1.0",
+    "grunt-contrib-uglify": "^0.2.7",
+    "karma-chrome-launcher": "^0.1.2",
+    "karma-coffee-preprocessor": "^0.1.2",
+    "karma-mocha": "^0.1.1",
+    "karma-script-launcher": "^0.1.0",
+    "karma-phantomjs-launcher": "^0.1.1",
+    "requirejs": "^2.1.10",
+    "karma-jasmine": "^0.1.5",
+    "karma-requirejs": "^0.2.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gsklee/ngStorage"
+  },
+  "keywords": [
+    "localStorage",
+    "sessionStorage",
+    "angular"
+  ],
+  "bugs": {
+    "url": "https://github.com/gsklee/ngStorage/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ngStorage",
   "version": "0.3.0",
-  "private": true,
   "author": "Gias Kay Lee",
   "licenses": [
     {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "test": "./node_modules/.bin/grunt test"
   },
+  "main": "ngStorage.js",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-uglify": "~0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ngStorage",
+  "name": "ng-storage",
   "version": "0.3.0",
   "author": "Gias Kay Lee",
   "licenses": [


### PR DESCRIPTION
To do this, I had to make a few tweaks to the `package.json` file. Right now, `ng-storage` is [on NPM under my name](https://npmjs.org/package/ng-storage) but I would be happy to transfer ownership to someone else upon request.

Cheers!

~Max