### PR TITLE
Fix storage items deletion after $reset call

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -50,7 +50,7 @@
                         },
                         $reset: function(items) {
                             for (var k in $storage) {
-                                '$' === k[0] || delete $storage[k];
+                                '$' === k[0] || (delete $storage[k] && webStorage.removeItem('ngStorage-' + k));
                             }
 
                             return $storage.$default(items);


### PR DESCRIPTION
This fixes #48, a bug about not deleting items from the storage after
$reset being called.