### PR TITLE
Add try/catch block to prevent chrome from crashing - fixes #57

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -39,8 +39,7 @@
                 $log
             ){
                 // #9: Assign a placeholder object if Web Storage is unavailable to prevent breaking the entire AngularJS app
-                var webStorage = $window[storageType] || ($log.warn('This browser does not support Web Storage!'), {}),
-                    $storage = {
+                var $storage = {
                         $default: function(items) {
                             for (var k in items) {
                                 angular.isDefined($storage[k]) || ($storage[k] = items[k]);
@@ -57,7 +56,18 @@
                         }
                     },
                     _last$storage,
-                    _debounce;
+                    _debounce,
+                    webStorage;
+                
+                try {    
+                  webStorage = $window[storageType];
+                } catch(e) {
+                }
+                
+                if (!webStorage) {
+                    $log.warn('This browser does not support Web Storage!')
+                    webStorage = {};
+                }
 
                 for (var i = 0, k; i < webStorage.length; i++) {
                     // #8, #10: `webStorage.key(i)` may be an empty string (or throw an exception in IE9 if `webStorage` is empty)


### PR DESCRIPTION
Chrome crashes as described in #57 (similar to #9) when you check the following checkbox and load ngStorage in a cross domain iFrame:
![Chrome Security Settings](http://i.stack.imgur.com/B02MA.png)

It prevents the whole AngularJS application from bootstrapping:.

<pre>
Error: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.
    at Error (native)
    at Object.<anonymous> (https://rawgit.com/gsklee/ngStorage/master/ngStorage.js:42:41)
    at Object.d [as invoke] (https://code.angularjs.org/1.1.5/angular.min.js:28:304)
    at https://code.angularjs.org/1.1.5/angular.min.js:30:39
    at c (https://code.angularjs.org/1.1.5/angular.min.js:27:142)
    at d (https://code.angularjs.org/1.1.5/angular.min.js:27:276)
    at Object.instantiate (https://code.angularjs.org/1.1.5/angular.min.js:28:434)
    at https://code.angularjs.org/1.1.5/angular.min.js:53:326
    at https://code.angularjs.org/1.1.5/angular.min.js:44:274
    at n (https://code.angularjs.org/1.1.5/angular.min.js:7:74) 
</pre>