### PR TITLE
Move webStorage.length evaluation out the for-loop

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -59,7 +59,7 @@
                     _last$storage,
                     _debounce;
 
-                for (var i = 0, k, length = webStorage.length; i < length; i++) {
+                for (var i = 0, k, storageLength = webStorage.length; i < storageLength; i++) {
                     // #8, #10: `webStorage.key(i)` may be an empty string (or throw an exception in IE9 if `webStorage` is empty)
                     (k = webStorage.key(i)) && 'ngStorage-' === k.slice(0, 10) && ($storage[k.slice(10)] = angular.fromJson(webStorage.getItem(k)));
                 }

--- a/ngStorage.js
+++ b/ngStorage.js
@@ -59,7 +59,7 @@
                     _last$storage,
                     _debounce;
 
-                for (var i = 0, k; i < webStorage.length; i++) {
+                for (var i = 0, k, length = webStorage.length; i < length; i++) {
                     // #8, #10: `webStorage.key(i)` may be an empty string (or throw an exception in IE9 if `webStorage` is empty)
                     (k = webStorage.key(i)) && 'ngStorage-' === k.slice(0, 10) && ($storage[k.slice(10)] = angular.fromJson(webStorage.getItem(k)));
                 }


### PR DESCRIPTION
Standard JS best practice - this way the length is only calculated once.
Would only make a difference if the loop might change that length (which shouldn't happen).
