### PR TITLE
use strict - Placement changed

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -1,6 +1,6 @@
-'use strict';
 
 (function() {
+'use strict';
 
     /**
      * @ngdoc overview


### PR DESCRIPTION
'use strict'; should be inside of the function since it is function scope

Fixes cross script compatibility issues