### PR TITLE
Add 'main' field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
       "url": "https://github.com/gsklee/ngStorage/blob/master/LICENSE"
     }
   ],
+  "main": "ngStorage.js",
   "scripts": {
     "test": "./node_modules/.bin/grunt test"
   },


### PR DESCRIPTION
Build tools like [browserify](http://browserify.org/) don't know what to import if there is neither an `index.js` file in the repo nor a `"main": "whateverYouNamedTheMainEntryPoint.js"` key-value pair in the module's [`package.json`](https://docs.npmjs.com/files/package.json#main).

This PR adds the appropriate key to `package.json`.