### PR TITLE
Use anonymous AMD definition

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -1,7 +1,7 @@
 (function(angular, factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
-        define('ngStorage', ['angular'], function(angular) {
+        define(['angular'], function(angular) {
             return factory(angular);
         });
     } else {


### PR DESCRIPTION
When a file defines only one AMD module, named definitions limit flexibility while offering no advantages over anonymous ones. (issue #89)