### PR TITLE
Fix CommonJS/Browserify support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@
 !LICENSE
 !ngStorage.js
 !ngStorage.min.js
+!index.js

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./ngStorage.js');
+module.exports = 'ngStorage';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/gsklee/ngStorage/blob/master/LICENSE"
     }
   ],
-  "main": "ngStorage.js",
+  "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/grunt test"
   },


### PR DESCRIPTION
When using with browserify, we have error like this:

 ```
Error: Cannot find module 'ngstorage' from '/Users/.....'
```


This PR fix this and allows us to write this:

```
var angular = require('angular');

angular.module('App', [
	require('angular-ui-router'),
	require('ngstorage')
]);
```
