### PR TITLE
fix DOM Exception 18 when cookies are blocked by user in Safari

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -50,7 +50,16 @@
                 $timeout
             ){
                 function isStorageSupported(storageType) {
-                    var supported = $window[storageType];
+
+                    // fix 'SecurityError: DOM Exception 18' exception in Desktop Safari, Mobile Safari
+                    // when "Block cookies": "Always block" is turned on
+                    var supported;
+                    try {
+                        supported = $window[storageType];
+                    }
+                    catch (err) {
+                        supported = false;
+                    }
 
                     // When Safari (OS X or iOS) is in private browsing mode, it appears as though localStorage
                     // is available, but trying to call .setItem throws an exception below:


### PR DESCRIPTION
If cookies are disabled in Safari browser (`Privacy —> Cookies and website data —> "Always block"`), then simply calling localStorage (`$window['localStorage']`) throws an error, which breaks the whole app.

This fix simply catches the error.