### PR TITLE
Custom storage key prefix

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -30,7 +30,7 @@
      * @requires $window
      */
 
-    .factory('$localStorage', _storageFactory('localStorage'))
+    .provider('$localStorage', _storageProvider('localStorage'))
 
     /**
      * @ngdoc object
@@ -39,21 +39,22 @@
      * @requires $window
      */
 
-    .factory('$sessionStorage', _storageFactory('sessionStorage'));
+    .provider('$sessionStorage', _storageProvider('sessionStorage'));
 
-    function _storageFactory(storageType) {
-        return [
-            '$rootScope',
-            '$window',
-            '$log',
-            '$timeout',
+    function _storageProvider(storageType) {
+        return function () {
+          this.$get = [
+              '$rootScope',
+              '$window',
+              '$log',
+              '$timeout',
 
-            function(
-                $rootScope,
-                $window,
-                $log,
-                $timeout
-            ){
+              function(
+                  $rootScope,
+                  $window,
+                  $log,
+                  $timeout
+              ){
                 function isStorageSupported(storageType) {
 
                     // Some installations of IE, for an unknown reason, throw "SCRIPT5: Error: Access is denied"
@@ -156,6 +157,7 @@
                 return $storage;
             }
         ];
+      };
     }
 
 }));

--- a/ngStorage.js
+++ b/ngStorage.js
@@ -43,6 +43,15 @@
 
     function _storageProvider(storageType) {
         return function () {
+          var storageKeyPrefix = 'ngStorage-';
+
+          this.setKeyPrefix = function (prefix) {
+            if (typeof prefix !== 'string') {
+              throw new TypeError('[ngStorage] - ' + storageType + 'Provider.setKeyPrefix() expects a String.');
+            }
+            storageKeyPrefix = prefix;
+          };
+
           this.$get = [
               '$rootScope',
               '$window',
@@ -102,7 +111,7 @@
                         },
                         $reset: function(items) {
                             for (var k in $storage) {
-                                '$' === k[0] || (delete $storage[k] && webStorage.removeItem('ngStorage-' + k));
+                                '$' === k[0] || (delete $storage[k] && webStorage.removeItem(storageKeyPrefix + k));
                             }
 
                             return $storage.$default(items);
@@ -110,7 +119,7 @@
                         $sync: function () {
                             for (var i = 0, l = webStorage.length, k; i < l; i++) {
                                 // #8, #10: `webStorage.key(i)` may be an empty string (or throw an exception in IE9 if `webStorage` is empty)
-                                (k = webStorage.key(i)) && 'ngStorage-' === k.slice(0, 10) && ($storage[k.slice(10)] = angular.fromJson(webStorage.getItem(k)));
+                                (k = webStorage.key(i)) && storageKeyPrefix === k.slice(0, 10) && ($storage[k.slice(10)] = angular.fromJson(webStorage.getItem(k)));
                             }
                         }
                     },
@@ -129,13 +138,13 @@
                         if (!angular.equals($storage, _last$storage)) {
                             temp$storage = angular.copy(_last$storage);
                             angular.forEach($storage, function(v, k) {
-                                angular.isDefined(v) && '$' !== k[0] && webStorage.setItem('ngStorage-' + k, angular.toJson(v));
+                                angular.isDefined(v) && '$' !== k[0] && webStorage.setItem(storageKeyPrefix + k, angular.toJson(v));
 
                                 delete temp$storage[k];
                             });
 
                             for (var k in temp$storage) {
-                                webStorage.removeItem('ngStorage-' + k);
+                                webStorage.removeItem(storageKeyPrefix + k);
                             }
 
                             _last$storage = angular.copy($storage);
@@ -145,7 +154,7 @@
 
                 // #6: Use `$window.addEventListener` instead of `angular.element` to avoid the jQuery-specific `event.originalEvent`
                 $window.addEventListener && $window.addEventListener('storage', function(event) {
-                    if ('ngStorage-' === event.key.slice(0, 10)) {
+                    if (storageKeyPrefix === event.key.slice(0, 10)) {
                         event.newValue ? $storage[event.key.slice(10)] = angular.fromJson(event.newValue) : delete $storage[event.key.slice(10)];
 
                         _last$storage = angular.copy($storage);

--- a/test/spec.js
+++ b/test/spec.js
@@ -26,7 +26,7 @@ describe('ngStorage', function() {
 
         describe('$' + storageType, function() {
 
-            var $window, $rootScope, $storage, $timeout;
+            var $window, $rootScope, $storage, $storageProvider, $timeout;
 
             function initStorage(initialValues) {
 
@@ -52,9 +52,10 @@ describe('ngStorage', function() {
                     key: function(i) { return Object.keys(this.data)[i]; }
                 };
 
-                module(function($provide) {
+                module(['$provide', '$' + storageType + 'Provider', function($provide, _$storageProvider_) {
                     $provide.value('$window', $window);
-                });
+                    $storageProvider = _$storageProvider_;
+                }]);
 
                 inject(['$rootScope', '$' + storageType, '$timeout',
                     function(_$rootScope_, _$storage_, _$timeout) {
@@ -320,9 +321,29 @@ describe('ngStorage', function() {
                 });
             });
 
+            describe('when the key prefix is changed', function() {
+
+                beforeEach(function() {
+                    initStorage({});
+                    $storageProvider.setKeyPrefix('foo-');
+                });
+
+                it('should reflect the change', function(done) {
+                    $storage.bar = 'baz';
+                    $rootScope.$digest();
+
+                    $timeout.flush();
+
+                    setTimeout(function() {
+                        expect($window[storageType].getItem('foo-bar')).to.not.be.undefined;
+                        done();
+                    }, 125);
+
+                });
+
+            });
+
         });
     }
 
 });
-
-


### PR DESCRIPTION
Closes #114.

~~The refactor part created a nasty indentation diff, maybe I should keep the indentation as before, it's quite awkward as it is already.~~ (fixed this)

Makes it possible to change the prefix by

```js
angular.module('app')
    .config(function ($sessionStorageProvider, $localStorageProvider) {
        $sessionStorageProvider.setKeyPrefix('customPrefix-');
        $localStorageProvider.setKeyprefix('fooBar-');
    });
```