### PR TITLE
Add check for angular AND angular.module.

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -14,7 +14,7 @@
 
     // RequireJS does not pass in Angular to us (will be undefined).
     // Fallback to window which should mostly be there.
-    angular = angular || window.angular;
+    angular = (angular && angular.module ) ? angular : window.angular;
 
     /**
      * @ngdoc overview


### PR DESCRIPTION
This should surely mean angular is correctly defined?

Should fix #123.