### PR TITLE
Test sessionStorage prior to usage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "ngstorage",
-    "version": "0.3.11",
+    "version": "0.3.10",
     "main": "./ngStorage.js",
     "keywords": [
         "angular",
@@ -31,6 +31,6 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com/sime/ngStorage.git"
+        "url": "git://github.com/gsklee/ngStorage.git"
     }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "ngstorage",
-    "version": "0.3.10",
+    "version": "0.3.11",
     "main": "./ngStorage.js",
     "keywords": [
         "angular",
@@ -31,6 +31,6 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com/gsklee/ngStorage.git"
+        "url": "git://github.com/sime/ngStorage.git"
     }
 }

--- a/ngStorage.js
+++ b/ngStorage.js
@@ -114,12 +114,12 @@
                     // When Safari (OS X or iOS) is in private browsing mode, it appears as though localStorage
                     // is available, but trying to call .setItem throws an exception below:
                     // "QUOTA_EXCEEDED_ERR: DOM Exception 22: An attempt was made to add something to storage that exceeded the quota."
-                    if (supported && storageType === 'localStorage') {
+                    if (supported && (storageType === 'localStorage' || storageType === 'sessionStorage')) {
                         var key = '__' + Math.round(Math.random() * 1e7);
 
                         try {
-                            localStorage.setItem(key, key);
-                            localStorage.removeItem(key);
+                            $window[storageType].setItem(key, key);
+                            $window[storageType].removeItem(key);
                         }
                         catch (err) {
                             supported = false;


### PR DESCRIPTION
We use sessionStorage a lot, thus get plenty QUOTA_EXCEEDED_ERR errors when using it on private Safari.