### PR TITLE
Test sessionStorage prior to usage

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -114,12 +114,12 @@
                     // When Safari (OS X or iOS) is in private browsing mode, it appears as though localStorage
                     // is available, but trying to call .setItem throws an exception below:
                     // "QUOTA_EXCEEDED_ERR: DOM Exception 22: An attempt was made to add something to storage that exceeded the quota."
-                    if (supported && storageType === 'localStorage') {
+                    if (supported && (storageType === 'localStorage' || storageType === 'sessionStorage')) {
                         var key = '__' + Math.round(Math.random() * 1e7);
 
                         try {
-                            localStorage.setItem(key, key);
-                            localStorage.removeItem(key);
+                            $window[storageType].setItem(key, key);
+                            $window[storageType].removeItem(key);
                         }
                         catch (err) {
                             supported = false;


### PR DESCRIPTION
I'm re-sending this PR as I have rediscovered the bug again.

Attempting to use sessionStorage in private mode Safari (OS X or iOS) throws an ugly exception.

Plnkr to test.
Code: http://plnkr.co/edit/BFLWePaqO9xEP599zZlP?p=preview
Demo only: http://run.plnkr.co/G9RB1ANSfL0k3X6P/

Interestingly once the exception is thrown by sessionStorage, further attempts to use localStorage also throws an exception.
