### PR TITLE
Update webStorage on route change, rather then manual intervention

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -212,6 +212,18 @@
                     $storage.$apply();
                 });
 
+                if ($injector.has('$state')) {
+                    $rootScope.$on('$stateChangeStart', function () {
+                        $storage.$apply();
+                    });
+                }
+
+                if ($injector.has('$route')) {
+                    $rootScope.$on('$routeChangeStart', function() {
+                        $storage.$apply();
+                    });
+                }
+
                 return $storage;
               }
           ];


### PR DESCRIPTION
Currently if a storage modification is done followed by a route change, it is possible that the changes haven't been committed and thus not available. This PR is the Angular equivalent to the `beforeunload` listener.

Rather than making the user manually specify a $timeout() prior to a route change, I think it is of greater convenience to execute `$storage.$apply()` on `$routeChangeStart`/`$stateChangeStart`.

If this may be a undesirable default behaviour, a configuration option can easily be set up.