### PR TITLE
Add the nuget package to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ npm install ngstorage
 
 *NOTE:* We are `ngstorage` and *NOT* `ngStorage`. The casing is important!
 
+### nuget
+
+```bash
+Install-Package gsklee.ngStorage
+```
+
+Or search for `Angular ngStorage` in the nuget package manager. <https://www.nuget.org/packages/gsklee.ngStorage>
+
 CDN
 ===
 


### PR DESCRIPTION
I have uploaded a package to nuget for others to use, my work uses nuget for packages and so instead of downloading and keeping a certain version of this script I've decided to keep up the nuget package.

I can upload the actual package, if that is so desired.