### PR TITLE
Check if sessionStorage is supported on Safari

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -33,15 +33,14 @@
         supported = false;
       }
 
-      // When Safari (OS X or iOS) is in private browsing mode, it appears as though localStorage
+      // When Safari (OS X or iOS) is in private browsing mode, it appears as though localStorage and sessionStorage
       // is available, but trying to call .setItem throws an exception below:
       // "QUOTA_EXCEEDED_ERR: DOM Exception 22: An attempt was made to add something to storage that exceeded the quota."
-      if(supported && storageType === 'localStorage') {
+      if(supported) {
         var key = '__' + Math.round(Math.random() * 1e7);
-
         try {
-          localStorage.setItem(key, key);
-          localStorage.removeItem(key);
+          $window[storageType].setItem(key, key);
+          $window[storageType].removeItem(key, key);
         }
         catch(err) {
           supported = false;


### PR DESCRIPTION
Session storage in Safari in private mode is also throwing `QUOTA_EXCEEDED_ERR: DOM Exception 22` error