### PR TITLE
Optimizing the apply function

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -178,7 +178,7 @@
                             if (!angular.equals($storage, _last$storage)) {
                                 temp$storage = angular.copy(_last$storage);
                                 angular.forEach($storage, function(v, k) {
-                                    if (angular.isDefined(v) && '$' !== k[0]) {
+                                    if (!angular.equals(v, _last$storage[k]) && angular.isDefined(v) && '$' !== k[0]) {
                                         webStorage.setItem(storageKeyPrefix + k, serializer(v));
                                         delete temp$storage[k];
                                     }


### PR DESCRIPTION
I integrated a custom serializer and deserializer (in order to put gzip the content using lz-string lib). However, changing a certain setting caused all the keys to get reset in localStorage. Besides the entry that needs changing, also other entries are refreshed where this is not needed. Combine that with a rather slow/expensive compress function, this leads to performance degradation. 

The PR checks if the key is actually changed before resetting it in the storageProvider. 