### PR TITLE
Add $ngStorageChanged event after apply with changes

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -190,6 +190,8 @@
                                 }
 
                                 _last$storage = angular.copy($storage);
+
+                               $rootScope.$broadcast('$ngStorageChanged');
                             }
                         },
                         $supported: function() {

--- a/test/spec.js
+++ b/test/spec.js
@@ -153,6 +153,27 @@ describe('ngStorage', function() {
 
             });
 
+            it('should broadcast a $ngStorageChanged event after applying changes',
+	        function (done) {
+                
+		initStorage({'ngStorage-entry': '"initial"'});
+                
+		var changedHandlerInvoked = false;
+                $rootScope.$on('$ngStorageChanged', function () {
+                     changedHandlerInvoked = true;
+		});
+		
+		$storage.entry = 'updated';
+		$rootScope.$digest();
+
+                $timeout.flush();
+
+		setTimeout(function () {
+		    expect(changedHandlerInvoked).to.equal(true);
+		    done();
+		}, 125);
+            });
+
             describe('when $reset is called with no arguments', function() {
 
                 beforeEach(function(done) {


### PR DESCRIPTION
If we detect changes during the `apply` phase, we broadcast a $ngStorageChanged event on the $rootScope.

Additionally, since we also detect any changes to the underlying storage and apply those in the same manner, this event will be broadcast when the change might have come from a different tab.

Fixes #214 