### PR TITLE
try-catch in serialize / deserialize functions for non-JSON local storage values

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -89,8 +89,23 @@
             storageKeyPrefix = prefix;
           };
 
-          var serializer = angular.toJson;
-          var deserializer = angular.fromJson;
+          var serializer = function (value){
+              try {
+                  return angular.toJson(value);
+              }
+              catch (err){
+                  return value;
+              }
+          };
+          
+          var deserializer = function (value){
+              try {
+                  return angular.fromJson(value);
+              }
+              catch (err){
+                  return value;
+              }
+          };
 
           this.setSerializer = function (s) {
             if (typeof s !== 'function') {


### PR DESCRIPTION
Fixes issue #204. When a non-valid JSON value was in the local storage (set by an external application for example - like 'abc' instead of '"abc"'), an error would be thrown. Now, it will just set the value without parsing it from JSON.

It is possible to include this fix into the existing release by using the setSerializer / setDeserializer (which I've done in my application).

We might want to include a test for this specific use case?
