### PR TITLE
Implemet a workaround for IOS Devices with an older WebKit, which is not firiging beforeunload

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -224,8 +224,15 @@
                         $rootScope.$apply();
                     }
                 });
+				
+				
 
                 $window.addEventListener && $window.addEventListener('beforeunload', function() {
+                    $storage.$apply();
+                });
+				
+				// workaround for IOS devices (IPhone, IPad) with older WebKit version
+				$window.addEventListener && $window.addEventListener('pagehide', function() {
                     $storage.$apply();
                 });
 


### PR DESCRIPTION
Additionally listen to the event 'pagehide', which is fired by older WebKit browsers instead of 'beforeunload'. The event listener for 'pagehide' does the same ("$storage.apply()") as the listener for 'beforeunload'

Regards,
Babu