### PR TITLE
Update README.md, CDN to new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cdnjs now hosts ngStorage at <https://cdnjs.com/libraries/ngStorage>
 To use it
 
 ``` html
-<script src="https://cdnjs.cloudflare.com/ajax/libs/ngStorage/0.3.6/ngStorage.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ngStorage/0.3.10/ngStorage.min.js"></script>
 ```
 
 ### jsDelivr
@@ -62,7 +62,7 @@ jsDelivr hosts ngStorage at <http://www.jsdelivr.com/#!ngstorage>
 To use is
 
 ``` html
-<script src="https://cdn.jsdelivr.net/ngstorage/0.3.6/ngStorage.min.js"></script>
+<script src="https://cdn.jsdelivr.net/ngstorage/0.3.10/ngStorage.min.js"></script>
 ```
 
 Usage


### PR DESCRIPTION
The 3.10.0 has many things that 3.6.0 doesn't, I was looking for errors with setKeyPrefix, in the source(raw github) the function exists, but since I just got the CDN there wasn't.