### PR TITLE
Return module name at end of chain

### DIFF
--- a/ngStorage.js
+++ b/ngStorage.js
@@ -74,7 +74,9 @@
      * @requires $window
      */
 
-    .provider('$sessionStorage', _storageProvider('sessionStorage'));
+    .provider('$sessionStorage', _storageProvider('sessionStorage'))
+  
+    .name;
 
     function _storageProvider(storageType) {
         var providerWebStorage = isStorageSupported(window, storageType);


### PR DESCRIPTION
Return module name at end of chain so that so that it can be used in es6 style code without a literal string module name.

For example:

```
import ngStorage from 'ngstorage';

angular.module('myApp', [ngStorage]);
```